### PR TITLE
Add bash completion script

### DIFF
--- a/containers/python-3-node/.devcontainer/Dockerfile
+++ b/containers/python-3-node/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:$imageVersion
 RUN groupadd docker \
   && apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
   && apt-get install --no-install-recommends -qq -y \
-    ca-certificates curl git gnupg2 lsb-release ssh sudo \
+    ca-certificates curl git bash-completion gnupg2 lsb-release ssh sudo \
     python3-pip python-is-python3 \
   && curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
   && apt-get update -qq -y \


### PR DESCRIPTION
Fixes #3 

## Changelog

Add Bash completion script. For example, one can now press TAB to see a list of git branches that start with the specified prefix.

```console
$ git switch add-feature-
add-feature-a   add-feature-b
```