### PR TITLE
Add OpenJDK 17 JRE

### DIFF
--- a/containers/python-3-node/.devcontainer/Dockerfile
+++ b/containers/python-3-node/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd docker \
   && apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
   && apt-get install --no-install-recommends -qq -y \
     ca-certificates curl git bash-completion gnupg2 lsb-release ssh sudo \
-    python3-pip python-is-python3 \
+    python3-pip python-is-python3 openjdk-17-jre \
   && curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
   && apt-get update -qq -y \
   && apt-get install --no-install-recommends -qq -y \


### PR DESCRIPTION
Add OpenJDK 17 JRE required to run the OpenAPI generator.

Published manually as
- `sagebionetworks/python-3-node:latest`
- `sagebionetworks/python-3-node:0.2.0`